### PR TITLE
Add MDX events and dynamic pages

### DIFF
--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -1,0 +1,26 @@
+import Image from "next/image";
+import { getEventBySlug, getEventSlugs } from "@/lib/events";
+
+export async function generateStaticParams() {
+  const slugs = await getEventSlugs();
+  return slugs.map((slug) => ({ slug }));
+}
+
+export default async function EventPage({ params }: { params: { slug: string } }) {
+  const { meta, content } = await getEventBySlug(params.slug);
+
+  return (
+    <article className="prose mx-auto py-8">
+      <h1>{meta.title}</h1>
+      <p>{meta.date}</p>
+      <Image
+        src={meta.thumbnail}
+        alt={meta.title}
+        width={800}
+        height={400}
+        className="rounded-md my-4"
+      />
+      <div>{content}</div>
+    </article>
+  );
+}

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -1,0 +1,30 @@
+import Image from "next/image";
+import Link from "next/link";
+import { EventMeta } from "@/lib/events";
+
+export interface EventCardProps {
+  event: EventMeta & { slug: string };
+}
+
+export default function EventCard({ event }: EventCardProps) {
+  return (
+    <Link
+      href={`/events/${event.slug}`}
+      className="block rounded-lg overflow-hidden border hover:shadow-lg transition-shadow"
+    >
+      <Image
+        src={event.thumbnail}
+        alt={event.title}
+        width={600}
+        height={300}
+        className="w-full h-48 object-cover"
+      />
+      <div className="p-4">
+        <h3 className="text-lg font-semibold mb-2 line-clamp-2">
+          {event.title}
+        </h3>
+        <p className="text-sm text-gray-500">{event.date}</p>
+      </div>
+    </Link>
+  );
+}

--- a/components/Events.tsx
+++ b/components/Events.tsx
@@ -1,0 +1,18 @@
+import { getAllEvents } from "@/lib/events";
+import EventCard from "./EventCard";
+
+export default async function Events() {
+  const events = await getAllEvents();
+
+  if (!events.length) {
+    return <p>No events found.</p>;
+  }
+
+  return (
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {events.map((event) => (
+        <EventCard key={event.slug} event={event} />
+      ))}
+    </div>
+  );
+}

--- a/content/events/sample-event.mdx
+++ b/content/events/sample-event.mdx
@@ -1,0 +1,9 @@
+---
+title: "Sample Event"
+date: "2025-08-12"
+thumbnail: "/sample.jpg"
+---
+
+## Welcome to the Sample Event
+
+This event demonstrates how MDX content can be rendered in Next.js.


### PR DESCRIPTION
## Summary
- add EventCard component for events
- add Events component that loads metadata from MDX files
- parse events using new helpers in `lib/events.ts`
- provide dynamic event route `app/events/[slug]/page.tsx`
- include a sample MDX file for events

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871082ed5488320ac3bd537d024a5fb